### PR TITLE
fix: restore wrapped API fetch errors

### DIFF
--- a/internal/client/weather-api.go
+++ b/internal/client/weather-api.go
@@ -50,7 +50,7 @@ func GetWeather(baseUrl, apiKey, city string) (*WeatherResponse, error) {
 			"erorr", err.(*url.Error).Err,
 		)
 
-		return nil, fmt.Errorf("error fecthing from api")
+		return nil, fmt.Errorf("error fetching from api: %w", err)
 	}
 
 	// closing the thing when im done with (saves memory)


### PR DESCRIPTION
## Summary
- fix the API fetch error message typo
- restore proper Go error wrapping with `%w`

## Testing
- `go test ./...`
- `go build ./...`

Fixes #14
